### PR TITLE
doc: Fix a small error in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,31 @@ Tmux status line configured in Rust.
 ## Features
 
 - Fully configured in Rust
-    - Type-save configuration
-    - Can be programmed (e.g. dynamically rendered modules)
+  - Type-save configuration
+  - Can be programmed (e.g. dynamically rendered modules)
 - Supports coloring
 - Multithreaded
 
 ## Installation
 
 1. Clone this repository
+
    ```bash
    git clone git@github.com:Dlurak/muxbar.git
    ```
+
 2. Install Muxbar
+
    ```bash
-   cargo install --path
+   cargo install --path .
    ```
+
 3. Apply Muxbar in your `.tmux.conf`
-   ```
+
+   ```text
    set -g status-right '#(muxbar)'
    ```
+
 ## Configuration
 
 The configuration is written in Rust and located in `./src/config.rs`


### PR DESCRIPTION
It is `cargo install --path .`
The other changes are just the result of a markdown linting/ formatting.